### PR TITLE
Modify DDB for performance bottlenecks module

### DIFF
--- a/code/sample-app/template.yaml
+++ b/code/sample-app/template.yaml
@@ -89,6 +89,9 @@ Resources:
   SampleTable:
     Type: AWS::Serverless::SimpleTable
     Properties:
+      ProvisionedThroughput:
+        ReadCapacityUnits: 10
+        WriteCapacityUnits: 5
       PrimaryKey:
         Name: id
         Type: String


### PR DESCRIPTION
Added DDB provisioned throughput for DDB table performance bottlenecks module. Without this, it defaults to pay per request (on-demand) and scales automatically. Whilst this is a good thing, we want the tracing module to reveal DynamoDB as the bottleneck and we do this by artificially capping the provisioned throughput similar to if a customer set it manually and under-provisioned.


### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

*Issue #, if available:*
https://github.com/aws-samples/serverless-observability-workshop/issues/29

Put closes `#XXXX` in your comment to auto-close the issue that your PR fixes (if such).
closes `#29`

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
