### PR TITLE
Set the region for the CDK helper

### DIFF
--- a/workshop/content/030_cloudwatch/dashboards/create_dashboard.es.md
+++ b/workshop/content/030_cloudwatch/dashboards/create_dashboard.es.md
@@ -25,7 +25,7 @@ npm outdated
 npm update --force
 npm install --force
 npm install -g typescript aws-cdk
-cdk deploy -c stack_name=monitoring-app
+export AWS_REGION=$(curl http://169.254.169.254/latest/meta-data/placement/region) cdk deploy -c stack_name=monitoring-app
 ```
 
 {{% notice tip %}}

--- a/workshop/content/030_cloudwatch/dashboards/create_dashboard.md
+++ b/workshop/content/030_cloudwatch/dashboards/create_dashboard.md
@@ -25,7 +25,7 @@ npm outdated
 npm update --force
 npm install --force
 npm install -g typescript aws-cdk
-cdk deploy -c stack_name=monitoring-app
+export AWS_REGION=$(curl http://169.254.169.254/latest/meta-data/placement/region) cdk deploy -c stack_name=monitoring-app
 ```
 
 {{% notice tip %}}

--- a/workshop/content/030_cloudwatch/dashboards/create_dashboard.pt.md
+++ b/workshop/content/030_cloudwatch/dashboards/create_dashboard.pt.md
@@ -25,7 +25,7 @@ npm outdated
 npm update --force
 npm install --force
 npm install -g typescript aws-cdk
-cdk deploy -c stack_name=monitoring-app
+export AWS_REGION=$(curl http://169.254.169.254/latest/meta-data/placement/region) cdk deploy -c stack_name=monitoring-app
 ```
 
 {{% notice tip %}}


### PR DESCRIPTION
*Description of changes:*

Automatically set the region for creatin the CloudWatch dashboard via CDK.
Without this, the CDK stack fail with the following message:

```
/home/ec2-user/environment/serverless-observability-workshop/code/cloudwatch-cdk/lib/helper/cloudformation-parser.ts:22
throw new Error(err)
^
Error: ConfigError: Missing region in config
```

This is maybe something that can be fixed automatically to upgrade to AWS SDK v3 (but not sure, I need to dive deep)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
